### PR TITLE
Updated readme to reflect new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,9 @@ Curl files to running JCR
 
     gulp.task('watch', function() {
         gulp.watch('js/*.js', function(e) {
-            var path = e.path;
-            return gulp.src(path)
-                .pipe(slang(path, {
-                    port: 4503
-                }));
+            slang(e, {
+                port: 4503
+            });
         });
     });
 ```


### PR DESCRIPTION
The example in the current readme does not work with v0.2.0.
This updates the example code.
