### PR TITLE
remove backslash after jcr_root to be compatible with windows cli

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ function slang(opt) {
         }
         // if jcr_root is in file system path, remove before setting destination
         var destPath = file.path;
-        if (path.dirname(destPath).indexOf('jcr_root/') !== -1) {
+        if (path.dirname(destPath).indexOf('jcr_root') !== -1) {
             destPath = destPath.substring(path.dirname(destPath)
-                .indexOf('jcr_root/') + 9);
+                .indexOf('jcr_root') + 9);
         }
 
         // create full URL for curl path


### PR DESCRIPTION
get rid of the backslash after jcr_root in the file.path to avoid error(the path modification wouldn't run) when running windows command line
